### PR TITLE
Update app to fix most

### DIFF
--- a/app.py
+++ b/app.py
@@ -263,34 +263,27 @@ class CellViewer(pn.viewable.Viewer):
         points = hd.dynspread(points, threshold=0.9, max_px=15)
         self.selection_stream.source = points
 
-        labels_shadows = (
-            self.obs_df.groupby(self.leiden_res, as_index=False, observed=False)[
-                ["UMAP1", "UMAP2"]
-            ]
-            .mean()
-            .hvplot.labels(
-                x="UMAP1",
-                y="UMAP2",
-                text=self.leiden_res,
-                text_color="white",
-                hover=False,
-                responsive=True,
-            )
+        labels_df = self.obs_df.groupby(
+            self.leiden_res, as_index=False, observed=False
+        )[["UMAP1", "UMAP2"]].mean()
+        labels_shadows = labels_df.hvplot.labels(
+            x="UMAP1",
+            y="UMAP2",
+            text=self.leiden_res,
+            text_color="white",
+            hover=False,
+            responsive=True,
+            font_size="12px"
         )
 
-        labels = (
-            self.obs_df.groupby(self.leiden_res, as_index=False, observed=False)[
-                ["UMAP1", "UMAP2"]
-            ]
-            .mean()
-            .hvplot.labels(
-                x="UMAP1",
-                y="UMAP2",
-                text=self.leiden_res,
-                text_color="black",
-                hover=False,
-                responsive=True,
-            )
+        labels = labels_df.hvplot.labels(
+            x="UMAP1",
+            y="UMAP2",
+            text=self.leiden_res,
+            text_color="black",
+            hover=False,
+            responsive=True,
+            font_size="13px"
         )
 
         inspector = hd.inspect_points.instance(
@@ -460,7 +453,7 @@ class CellViewer(pn.viewable.Viewer):
         }
 
         dotplot = self._plot_dotplot(df, clusters_ordered, cluster_positions)
-    
+
         try:
             dendro_data = self._prepare_dendrogram(cluster_gene_matrix)
             dendrogram = self._plot_dendrogram(


### PR DESCRIPTION
- [x] Make sizing responsive
  - partially resolved. `responsive = True` is not respected for dotplot when dendrogram present (Layout rather than Element).. bug?
  - https://github.com/holoviz/panel/issues/7469

- [x] axis ticks are overlapping and unreadable
- [x] Remove background grey color/pane of served app main area. Makes colorbar background look bad.
- [x] UMAP points are microscopic.. set pixel_ratio to less than 1... fixed but looks pretty bad
- [x] tap-inspection red box color clashes and gets lost with umap colormap. how other to show tap point. Exclude red from the colormap?
- [x] move colorbar opposite from dendrogram
- [x] use dynspread directly instead of pixel_ratio on umap to make points more visible but not overly pixelated.
- [x] Only include a single dotplot, not two. Put the dendrogram and heatmap annotation bar on this single dotplot.
- [x] ~~selection on umap does not change the extent of cluster axis ticks in the dotplot.~~
  - ~~not sure what the most useful behavior should be.. right now shows the entire cluster row in dotplot if any points in cluster are in umap selection, instead of limiting the dotplot row dots to just the selected points.~~
  - UPDATE: feedback from charlie is to make the selection per point between plots. Replace the custom box_select stream with [link_selections](https://holoviews.org/user_guide/Linked_Brushing.html#python-based-linked-brushing).
- [x] box selection indicator doesn't persist or style the umap points in a differentiable way. Cannot use BoxEdit stream because the double tap to create conflict with tap to inspect in this app
- [x] Link dendrogram Y cluster axis to dotplot
- [x] ~~cannot reset selection from umap to reset the dotplot.~~ update: should be resolved when using link_selections instead
- [x] remove *_colors from lieden_res dropdown options

Other (only if there's time)
- [ ] utilize `apply_when` or `resample_when` (tried using the kwarg, but inspect_points requires it to not be an overlay; will probably need the full implementation https://discourse.holoviz.org/t/how-to-show-hide-overlay-depending-on-zoom-level/61/2?u=ahuang11)
- [ ] Missing dot size legend
- [ ] max dot size should probably not be exposed and instead computed automatically to avoid neighbor overlap (I have a minimal example; just didn't have time https://discourse.holoviz.org/t/make-points-scale-with-plot-window-size/8385/1)
- [x] Labels are hard to see and can overlap with each other. Auto 'dodge' label position to avoid overlap. Add white outline to font.

<img width="1308" alt="image" src="https://github.com/user-attachments/assets/00d16f11-5f5b-43ef-a3d1-6098a5d73b8b">
